### PR TITLE
Add WaveSpeed image/video generation plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ This project stores [Plugins](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web
 | [Jina URL Content Reader](./plugins/jina-r) | - | Converts any URL to an LLM-friendly input |
 | [Kolors SilliconFlow Draw API](./plugins/KolorsSiliconFlow) | bearer | Draws images from text prompts with model Kwai-Kolors/Kolors |
 | [Tavily Search](./plugins/tavilysearch) | bearer | Tavily is a search engine optimized for LLMs, aimed at efficient, quick and persistent search results. |
+| [WaveSpeed](./plugins/wavespeed) | bearer | Generate images and videos with WaveSpeed AI (Seedream, Seedance, FLUX and more) |
 

--- a/plugins/wavespeed/README.md
+++ b/plugins/wavespeed/README.md
@@ -1,0 +1,28 @@
+# WaveSpeed
+
+> Generate images and videos with [WaveSpeed AI](https://wavespeed.ai) — ByteDance Seedream / Seedance, FLUX, and the rest of the wavespeed.ai model catalog, served on a fast async prediction API.
+
+> Get an API key from the [WaveSpeed dashboard](https://wavespeed.ai/dashboard/apikeys). API reference: [wavespeed.ai/docs](https://wavespeed.ai/docs)
+
+## Schema
+[openapi.json](./openapi.json)
+
+## Servers
+
+`https://api.wavespeed.ai`
+
+## Operations
+
+1. `WaveSpeedSubmit` — `POST /api/v3/{model_id}` submits a generation task with `{"prompt": "..."}` and returns a prediction id. Default image model: `bytedance/seedream-v5.0-pro`. Any model id from [wavespeed.ai/models](https://wavespeed.ai/models) works, e.g. `bytedance/seedance-v1-pro-t2v-720p` for text-to-video.
+2. `WaveSpeedGetResult` — `GET /api/v3/predictions/{id}/result` polls the task. The model should call it again while `data.status` is `created`/`processing`, and when it is `completed`, show `data.outputs[0]` (the generated image/video URL) to the user.
+
+All responses use the envelope `{code, message, data: {id, status, outputs, error}}`.
+
+## Authentication
+
+```
+type: bearer
+location: header
+```
+
+Paste your WaveSpeed API key (from [wavespeed.ai/dashboard/apikeys](https://wavespeed.ai/dashboard/apikeys)) as the token.

--- a/plugins/wavespeed/openapi.json
+++ b/plugins/wavespeed/openapi.json
@@ -1,0 +1,149 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "WaveSpeed",
+    "description": "Generate images and videos with WaveSpeed AI (wavespeed.ai). Submit a prompt to a model, then poll the prediction result until it is completed and return the output URL.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.wavespeed.ai"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "paths": {
+    "/api/v3/{model_id}": {
+      "post": {
+        "operationId": "WaveSpeedSubmit",
+        "x-openai-isConsequential": false,
+        "summary": "Submit an image or video generation task to a WaveSpeed AI model. Returns a prediction id immediately; the task runs asynchronously. After calling this, poll WaveSpeedGetResult with the returned data.id until data.status is `completed`, then present data.outputs[0] (the image/video URL) to the user, e.g. as ![image](url).",
+        "parameters": [
+          {
+            "name": "model_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The WaveSpeed model id, in `owner/name` format and may contain slashes. Unless the user asks for a specific model, use `bytedance/seedream-v5.0-pro` for images. Other examples: `bytedance/seedance-v1-pro-t2v-720p` (text-to-video), `wavespeed-ai/flux-dev`. The full catalog is at https://wavespeed.ai/models."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["prompt"],
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text description of the desired image or video."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Task accepted. Remember `data.id` and poll WaveSpeedGetResult with it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/predictions/{id}/result": {
+      "get": {
+        "operationId": "WaveSpeedGetResult",
+        "x-openai-isConsequential": false,
+        "summary": "Get the result of a previously submitted WaveSpeed prediction. If data.status is `created` or `processing`, wait a moment and call this operation again (typically a few seconds for images, longer for videos). When data.status is `completed`, data.outputs[0] contains the generated image/video URL — show it to the user, e.g. as ![image](url). If data.status is `failed`, report data.error.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The prediction id returned by WaveSpeedSubmit (data.id)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current prediction state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "WaveSpeed API key from the wavespeed.ai dashboard."
+      }
+    },
+    "schemas": {
+      "PredictionEnvelope": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "description": "Platform status code; 200 on success."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable status or error message."
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Prediction id, used to poll the result."
+              },
+              "model": {
+                "type": "string",
+                "description": "The model that ran this prediction."
+              },
+              "status": {
+                "type": "string",
+                "description": "One of `created`, `processing`, `completed`, `failed`, `cancelled`, `timeout`."
+              },
+              "outputs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Generated image/video URLs; present when status is `completed`."
+              },
+              "error": {
+                "type": "string",
+                "description": "Error detail when status is `failed`."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds an official plugin for **WaveSpeed AI** ([wavespeed.ai](https://wavespeed.ai)) — I'm the founder (WaveSpeedAI). It lets NextChat generate images and videos with ByteDance Seedream / Seedance, FLUX, and the rest of the wavespeed.ai model catalog.

## How it works

- `WaveSpeedSubmit` — `POST /api/v3/{model_id}` with `{"prompt": "..."}` submits an async generation task (default image model: `bytedance/seedream-v5.0-pro`; any model id from https://wavespeed.ai/models works, e.g. `bytedance/seedance-v1-pro-t2v-720p` for text-to-video).
- `WaveSpeedGetResult` — `GET /api/v3/predictions/{id}/result` polls the task; the operation descriptions instruct the model to poll while `data.status` is `created`/`processing` and to return `data.outputs[0]` (the image/video URL) once `completed`.

All responses use the `{code, message, data: {id, status, outputs, error}}` envelope.

## Authentication

`bearer` in header, per repo convention — users paste their own API key from the wavespeed.ai dashboard.

## Files

- `plugins/wavespeed/openapi.json`
- `plugins/wavespeed/README.md`
- `README.md` — added the plugin to the index table

## Validation

`npx @redocly/cli lint plugins/wavespeed/openapi.json` → **valid**, 0 errors (3 warnings: missing `info.license` and no `4XX` responses declared, consistent with existing plugins in this repo).

---

Disclosure: this plugin was authored with AI assistance (Claude Code) and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJJXU9zyoDSBjApcUpteDt